### PR TITLE
グラフ画面の変更

### DIFF
--- a/client/emil/emil/AppDelegate.swift
+++ b/client/emil/emil/AppDelegate.swift
@@ -27,6 +27,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var last_week:JSON = ""
     var last2_week:JSON = ""
     
+    var this_week_total:JSON = ""
+    var last_week_total:JSON = ""
+    var last2_week_total:JSON = ""
+    
+    var segment_number = 0 //グラフで使うセグメントボタンの番号
+    
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
 
         let json = callAPI(name: "users", params:["1"])
@@ -34,10 +40,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         used_smilegae = json["used"].intValue
         total_smileage = available_smileage + used_smilegae
         
-        this_week = callAPI(name: "laughs/detail", params:["1","2017","11","12"])
-        last_week = callAPI(name: "laughs/detail", params:["1","2017","11","05"])
-        last2_week = callAPI(name: "laughs/detail", params:["1","2017","10","29"])
+//        this_week = callAPI(name: "laughs/detail", params:["1","2017","11","12"])
+//        last_week = callAPI(name: "laughs/detail", params:["1","2017","11","05"])
+//        last2_week = callAPI(name: "laughs/detail", params:["1","2017","10","29"])
         
+        this_week_total = callAPI(name: "laughs", params:["1","2017","11","12"])
+        last_week_total = callAPI(name: "laughs", params:["1","2017","11","05"])
+        last2_week_total = callAPI(name: "laughs", params:["1","2017","10","29"])
+
         return true
     }
     

--- a/client/emil/emil/AppDelegate.swift
+++ b/client/emil/emil/AppDelegate.swift
@@ -40,9 +40,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         used_smilegae = json["used"].intValue
         total_smileage = available_smileage + used_smilegae
         
-//        this_week = callAPI(name: "laughs/detail", params:["1","2017","11","12"])
-//        last_week = callAPI(name: "laughs/detail", params:["1","2017","11","05"])
-//        last2_week = callAPI(name: "laughs/detail", params:["1","2017","10","29"])
+        this_week = callAPI(name: "laughs/detail", params:["1","2017","11","12"])
+        last_week = callAPI(name: "laughs/detail", params:["1","2017","11","05"])
+        last2_week = callAPI(name: "laughs/detail", params:["1","2017","10","29"])
         
         this_week_total = callAPI(name: "laughs", params:["1","2017","11","12"])
         last_week_total = callAPI(name: "laughs", params:["1","2017","11","05"])

--- a/client/emil/emil/Base.lproj/Main.storyboard
+++ b/client/emil/emil/Base.lproj/Main.storyboard
@@ -26,24 +26,6 @@
                                     <action selector="moveTimeTable:" destination="BYZ-38-t0r" eventType="touchUpInside" id="acN-dD-Ct3"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8Aa-fD-Xwr">
-                                <rect key="frame" x="0.0" y="313" width="34" height="41"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="22"/>
-                                <state key="normal" title="＜"/>
-                                <connections>
-                                    <action selector="beforeGraph:" destination="BYZ-38-t0r" eventType="touchUpInside" id="fEq-PT-O9H"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cqd-LO-4sW">
-                                <rect key="frame" x="341" y="313" width="34" height="41"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="22"/>
-                                <state key="normal" title="＞"/>
-                                <connections>
-                                    <action selector="advancegraph:" destination="BYZ-38-t0r" eventType="touchUpInside" id="w93-Yk-NR2"/>
-                                </connections>
-                            </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="C9A-NR-BPk">
                                 <rect key="frame" x="187" y="608" width="188" height="59"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>

--- a/client/emil/emil/Base.lproj/Main.storyboard
+++ b/client/emil/emil/Base.lproj/Main.storyboard
@@ -78,6 +78,18 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <segmentedControl opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="IMR-FZ-Qh8">
+                                <rect key="frame" x="179" y="188" width="180" height="29"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <segments>
+                                    <segment title="今週"/>
+                                    <segment title="先週"/>
+                                    <segment title="2週間前"/>
+                                </segments>
+                                <connections>
+                                    <action selector="changeWeek:" destination="BYZ-38-t0r" eventType="valueChanged" id="CjQ-XZ-e35"/>
+                                </connections>
+                            </segmentedControl>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>

--- a/client/emil/emil/TimeTable.swift
+++ b/client/emil/emil/TimeTable.swift
@@ -13,7 +13,6 @@ class TimeTable: UIViewController, UICollectionViewDataSource, UICollectionViewD
     
     @IBOutlet weak var total_smile: UILabel!
     @IBOutlet weak var timetabelColelctionView: UICollectionView!
-    @IBOutlet weak var segment_week: UISegmentedControl!
     
     let appDelegate = UIApplication.shared.delegate as! AppDelegate
     

--- a/client/emil/emil/TimeTable.swift
+++ b/client/emil/emil/TimeTable.swift
@@ -32,13 +32,8 @@ class TimeTable: UIViewController, UICollectionViewDataSource, UICollectionViewD
     var segment_number = 0
     
     var skip_number: Int = 0
-    
-    var comment = ""
-    var laughs:JSON = ""
-    var laughs2:JSON = ""
-    var laughs3:JSON = ""
+
     //    let linePoint: CGFloat = 5     // 罫線の太さ
-    //    let numberOfCols: CGFloat = 7  // 1行に表示するセルの数
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -46,11 +41,7 @@ class TimeTable: UIViewController, UICollectionViewDataSource, UICollectionViewD
         timetabelColelctionView.delegate = self
         timetabelColelctionView.dataSource = self
         //        timetabelColelctionView.backgroundColor = UIColor.black
-        
-        
-        laughs = appDelegate.this_week
-        laughs2 = appDelegate.last_week
-        laughs3 = appDelegate.last2_week
+
     }
     
     override func didReceiveMemoryWarning() {
@@ -142,13 +133,13 @@ class TimeTable: UIViewController, UICollectionViewDataSource, UICollectionViewD
         cell.backgroundColor = UIColor.white
         
         if segment_number == 0 {
-            drow_background_cell(data: laughs, cell: cell, indexPath: indexPath)
+            drow_background_cell(data: appDelegate.this_week, cell: cell, indexPath: indexPath)
             
         }else if segment_number == 1{
-            drow_background_cell(data: laughs2, cell: cell, indexPath: indexPath)
+            drow_background_cell(data: appDelegate.last_week, cell: cell, indexPath: indexPath)
             
         }else if segment_number == 2{
-            drow_background_cell(data: laughs3, cell: cell, indexPath: indexPath)
+            drow_background_cell(data: appDelegate.last2_week, cell: cell, indexPath: indexPath)
             
         }
         cell.textLabel.text = weekArray[indexPath.row]
@@ -180,8 +171,8 @@ class TimeTable: UIViewController, UICollectionViewDataSource, UICollectionViewD
             for j in 0...6 {
                 if indexPath.row == skip_number {
                     
-                    print(indexPath.row)
-                    print(skip_number)
+//                    print(indexPath.row)
+//                    print(skip_number)
                     
                     switch data[i][j].intValue {
                     case 1...10:

--- a/client/emil/emil/Timetable.storyboard
+++ b/client/emil/emil/Timetable.storyboard
@@ -81,7 +81,6 @@
                         <viewLayoutGuide key="safeArea" id="acE-an-cPZ"/>
                     </view>
                     <connections>
-                        <outlet property="segment_week" destination="jOC-J9-0Fd" id="dHu-d7-UQQ"/>
                         <outlet property="timetabelColelctionView" destination="sss-on-K1f" id="q8r-Ah-gPQ"/>
                         <outlet property="total_smile" destination="Qv4-Cp-it6" id="xPJ-Ss-A9p"/>
                     </connections>

--- a/client/emil/emil/ViewController.swift
+++ b/client/emil/emil/ViewController.swift
@@ -18,13 +18,10 @@ class ViewController: UIViewController {
     
     let appDelegate = UIApplication.shared.delegate as! AppDelegate
     
+    var segment_number = 0
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        //viewを定義
-        let graphview = Graph(frame : CGRect(x: 30,y: 180,width: 300,height: 400))
-        graphview.backgroundColor = UIColor.white
-        view.addSubview(graphview)
         
         //スマイレージ
         let point = appDelegate.total_smileage
@@ -35,6 +32,12 @@ class ViewController: UIViewController {
         let image = UIImage(named: "smileage.png")
         // Image Viewに画像を設定
         smileage.image = image
+        
+        //viewを定義
+        let graphview = Graph(frame : CGRect(x: 30,y: 240,width: 300,height: 330))
+        graphview.backgroundColor = UIColor.white
+        view.addSubview(graphview)
+        
     }
     
     override func didReceiveMemoryWarning() {
@@ -56,19 +59,34 @@ class ViewController: UIViewController {
     
     //グラフを表示
     class Graph: UIView {
+        let appDelegate = UIApplication.shared.delegate as! AppDelegate
         override func draw(_ rect: CGRect) {
-            
-            let json = callAPI(name: "laughs", params:["1","2017","11","12"])
-            let each_day_points = json["weekly"]
-            print(each_day_points)
-            
-            for i in 0..<7 {
-                let point = each_day_points[i].intValue //笑った回数分のポイント
-                let path = UIBezierPath(roundedRect: CGRect(x: 20+i*40, y: 400-point/3, width: 30, height: point/3), cornerRadius: 0)
-                
-                UIColor.orange.setFill() // 色をセット
-                path.fill()
-                
+            if appDelegate.segment_number == 0 {
+                print("おう")
+                for i in 0..<7 {
+                    let point = appDelegate.this_week_total["weekly"][i].intValue //笑った回数分のポイント
+                    let path = UIBezierPath(roundedRect: CGRect(x: 20+i*40, y: 400-point/3, width: 30, height: point/3), cornerRadius: 0)
+                    
+                    UIColor.orange.setFill() // 色をセット
+                    path.fill()
+                }
+            }else if appDelegate.segment_number == 1 {
+                print("いえい")
+                for i in 0..<7 {
+                    let point = appDelegate.last_week_total["weekly"][i].intValue //笑った回数分のポイント
+                    let path = UIBezierPath(roundedRect: CGRect(x: 20+i*40, y: 400-point/3, width: 30, height: point/3), cornerRadius: 0)
+                    
+                    UIColor.orange.setFill() // 色をセット
+                    path.fill()
+                }
+            } else if appDelegate.segment_number == 2 {
+                for i in 0..<7 {
+                    let point = appDelegate.last2_week_total["weekly"][i].intValue //笑った回数分のポイント
+                    let path = UIBezierPath(roundedRect: CGRect(x: 20+i*40, y: 400-point/3, width: 30, height: point/3), cornerRadius: 0)
+                    
+                    UIColor.orange.setFill() // 色をセット
+                    path.fill()
+                }
             }
         }
     }
@@ -109,6 +127,28 @@ class ViewController: UIViewController {
         view.addSubview(graphview)
         
         week.text = "11月12日から一週間分のスマイレージ"
+    }
+    
+    @IBAction func changeWeek(_ sender: Any) {
+        switch (sender as AnyObject).selectedSegmentIndex {
+        case 0:
+            appDelegate.segment_number = 0
+            let graphview = Graph(frame : CGRect(x: 30,y: 240,width: 300,height: 330))
+            graphview.backgroundColor = UIColor.white
+            view.addSubview(graphview)
+        case 1:
+            appDelegate.segment_number = 1
+            let graphview = Graph(frame : CGRect(x: 30,y: 240,width: 300,height: 330))
+            graphview.backgroundColor = UIColor.white
+            view.addSubview(graphview)
+        case 2:
+            appDelegate.segment_number = 2
+            let graphview = Graph(frame : CGRect(x: 30,y: 240,width: 300,height: 330))
+            graphview.backgroundColor = UIColor.white
+            view.addSubview(graphview)
+        default:
+            break
+        }
     }
 }
 

--- a/client/emil/emil/ViewController.swift
+++ b/client/emil/emil/ViewController.swift
@@ -45,6 +45,49 @@ class ViewController: UIViewController {
         // Dispose of any resources that can be recreated.
     }
     
+    //グラフを表示
+    class Graph: UIView {
+        let appDelegate = UIApplication.shared.delegate as! AppDelegate
+        override func draw(_ rect: CGRect) {
+            
+            /*
+             セグメントボタンの選択箇所によってそれぞれのグラフを表示する
+             */
+            switch appDelegate.segment_number {
+            case 0:
+                drow_week_bar(data: appDelegate.this_week_total)
+            case 1:
+                drow_week_bar(data: appDelegate.last_week_total)
+            case 2:
+                drow_week_bar(data: appDelegate.last2_week_total)
+            default:
+                break
+            }
+        }
+        
+        /*
+         グラフの描画
+         */
+        func drow_week_bar(data:JSON){
+            for i in 0..<7 {
+                let point = data["weekly"][i].intValue //笑った回数分のポイント
+                let path = UIBezierPath(roundedRect: CGRect(x: 20+i*40, y: 400-point/3, width: 30, height: point/3), cornerRadius: 0)
+                
+                UIColor.orange.setFill() // 色をセット
+                path.fill()
+            }
+        }
+    }
+    
+    /*
+     ビューにグラフを配置する
+     */
+    func setGraph() {
+        let graphview = Graph(frame : CGRect(x: 30,y: 240,width: 300,height: 330))
+        graphview.backgroundColor = UIColor.white
+        view.addSubview(graphview)
+    }
+    
     @IBAction func moveTimeTable(_ sender: Any) {
         let storyboard: UIStoryboard = UIStoryboard(name: "Timetable", bundle: nil)
         let next: UIViewController = storyboard.instantiateInitialViewController()!
@@ -57,95 +100,20 @@ class ViewController: UIViewController {
         present(next, animated: true, completion: nil)
     }
     
-    //グラフを表示
-    class Graph: UIView {
-        let appDelegate = UIApplication.shared.delegate as! AppDelegate
-        override func draw(_ rect: CGRect) {
-            if appDelegate.segment_number == 0 {
-                print("おう")
-                for i in 0..<7 {
-                    let point = appDelegate.this_week_total["weekly"][i].intValue //笑った回数分のポイント
-                    let path = UIBezierPath(roundedRect: CGRect(x: 20+i*40, y: 400-point/3, width: 30, height: point/3), cornerRadius: 0)
-                    
-                    UIColor.orange.setFill() // 色をセット
-                    path.fill()
-                }
-            }else if appDelegate.segment_number == 1 {
-                print("いえい")
-                for i in 0..<7 {
-                    let point = appDelegate.last_week_total["weekly"][i].intValue //笑った回数分のポイント
-                    let path = UIBezierPath(roundedRect: CGRect(x: 20+i*40, y: 400-point/3, width: 30, height: point/3), cornerRadius: 0)
-                    
-                    UIColor.orange.setFill() // 色をセット
-                    path.fill()
-                }
-            } else if appDelegate.segment_number == 2 {
-                for i in 0..<7 {
-                    let point = appDelegate.last2_week_total["weekly"][i].intValue //笑った回数分のポイント
-                    let path = UIBezierPath(roundedRect: CGRect(x: 20+i*40, y: 400-point/3, width: 30, height: point/3), cornerRadius: 0)
-                    
-                    UIColor.orange.setFill() // 色をセット
-                    path.fill()
-                }
-            }
-        }
-    }
-    
-    //過去のグラフを表示（実際には上記のGraphで表示するようにする）
-    class Graph2: UIView {
-        override func draw(_ rect: CGRect) {
-            
-            let json = callAPI(name: "laughs", params:["1","2017","11","05"])
-            let each_day_points = json["weekly"]
-            
-            for i in 0..<7 {
-                let point = each_day_points[i].intValue //笑った回数分のポイント
-                let path = UIBezierPath(roundedRect: CGRect(x: 20+i*40, y: 400-point/3, width: 30, height: point/3), cornerRadius: 0)
-                
-                UIColor.orange.setFill() // 色をセット
-                path.fill()
-                
-            }
-        }
-    }
-    
-    //1つ前の過去のグラフを表示
-    @IBAction func beforeGraph(_ sender: Any) {
-        //viewを定義
-        let graphview = Graph2(frame : CGRect(x: 30,y: 180,width: 300,height: 400))
-        graphview.backgroundColor = UIColor.white
-        view.addSubview(graphview)
-        
-        week.text = "11月05日から一週間分のスマイレージ"
-    }
-    
-    //押すごとに最新のグラフを表示
-    @IBAction func advancegraph(_ sender: Any) {
-        //viewを定義
-        let graphview = Graph(frame : CGRect(x: 30,y: 180,width: 300,height: 400))
-        graphview.backgroundColor = UIColor.white
-        view.addSubview(graphview)
-        
-        week.text = "11月12日から一週間分のスマイレージ"
-    }
-    
     @IBAction func changeWeek(_ sender: Any) {
         switch (sender as AnyObject).selectedSegmentIndex {
         case 0:
             appDelegate.segment_number = 0
-            let graphview = Graph(frame : CGRect(x: 30,y: 240,width: 300,height: 330))
-            graphview.backgroundColor = UIColor.white
-            view.addSubview(graphview)
+            week.text = "11月12日から一週間分のスマイレージ"
+            setGraph()
         case 1:
             appDelegate.segment_number = 1
-            let graphview = Graph(frame : CGRect(x: 30,y: 240,width: 300,height: 330))
-            graphview.backgroundColor = UIColor.white
-            view.addSubview(graphview)
+            week.text = "11月05日から一週間分のスマイレージ"
+            setGraph()
         case 2:
             appDelegate.segment_number = 2
-            let graphview = Graph(frame : CGRect(x: 30,y: 240,width: 300,height: 330))
-            graphview.backgroundColor = UIColor.white
-            view.addSubview(graphview)
+            week.text = "10月29日から一週間分のスマイレージ"
+            setGraph()
         default:
             break
         }


### PR DESCRIPTION
グラフの表示の方法を変更しました。
・左右にあったボタンを消去し、セグメントでグラフを描画/切り替えができるようにしました
・ボタンを押したらグラフを描画するコードを大幅にリファクトしました

その他の変更
・TimeTable.swiftも同様ですが、Appdelegateとのやりとりをする変数を増やしすぎたので、ダイレクトでappdelegateとやりとりをすることで変数を余分に出さないようにしました